### PR TITLE
Use JSON key/value instead of screenscraping # of removed files

### DIFF
--- a/rpkiclientweb/outputparser.py
+++ b/rpkiclientweb/outputparser.py
@@ -10,7 +10,6 @@ BAD_MESSAGE_DIGEST_RE = re.compile(
 EXPIRED_MANIFEST_RE = re.compile(
     r"rpki-client: (?P<uri>.*): mft expired on (?P<expiry>.*)"
 )
-FILES_REMOVED = re.compile(r"rpki-client: Files removed: (?P<files_removed>[0-9]+)")
 MISSING_FILE_RE = re.compile(
     r"rpki-client: (?!rpki-client:)(?P<uri>.*): No such file or directory"
 )
@@ -125,16 +124,6 @@ class OutputParser:
                     bad_message_digest.group("uri"),
                     bad_message_digest.group("object"),
                 )
-
-    @property
-    def files_removed(self) -> int:
-        """Number of files removed during rpki-client run"""
-        for line in self.lines:
-            removed = FILES_REMOVED.match(line)
-            if removed:
-                return int(removed.group("files_removed"))
-
-        return 0
 
     @property
     def pulling(self) -> FrozenSet[str]:

--- a/rpkiclientweb/rpki_client.py
+++ b/rpkiclientweb/rpki_client.py
@@ -77,6 +77,8 @@ METADATA_LABELS = (
     "repositories",
     "vrps",
     "uniquevrps",
+    "cachedir_del_files",
+    "cachedir_del_dirs",
 )
 OPTIONAL_METADATA_LABELS = frozenset(
     [
@@ -209,7 +211,6 @@ class RpkiClient:
         for repo in parsed.pulled:
             RPKI_CLIENT_PULLED.labels(repo).set_to_current_time()
 
-        RPKI_OBJECTS_COUNT.labels(type="files_removed").set(parsed.files_removed)
         RPKI_OBJECTS_COUNT.labels(type="vanished_files").set(len(parsed.vanished_files))
         RPKI_OBJECTS_COUNT.labels(type="vanished_directories").set(
             len(parsed.vanished_directories)
@@ -257,7 +258,9 @@ class RpkiClient:
           "crls": 11833,
           "repositories": 13,
           "vrps": 87978,
-          "uniquevrps": 87978
+          "uniquevrps": 87978,
+          "cachedir_del_files": 105,
+          "cachedir_del_dirs": 31
         }
         ```
         """

--- a/tests/test_outputparser.py
+++ b/tests/test_outputparser.py
@@ -32,8 +32,6 @@ def test_parse_sample_stderr_missing_files():
     )
     assert any(map(lambda r: isinstance(r, ExpirationWarning), parser.warnings))
 
-    assert parser.files_removed == 479
-
 
 def test_parse_sample_aggregated():
     """


### PR DESCRIPTION
rpki-client 6.9 will emit the number of removed files and directories.

This might help negate the need to scrape STDOUT for those numbers

(source: https://marc.info/?l=openbsd-tech&m=161791052014346&w=2)
