### PR TITLE
Rename non-error metric to end in _status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ via a HTTP API.
 Changes
 =======
 
-main:
-  * nothing yet
+dev:
+  * rename `rpkiclient_fetch_error` metric to `rpkiclient_fetch_status` since it
+    includes non-error statuses (fixes #26).
 
 2021-06-24 v0.8.0:
   * rpki-client 7 support

--- a/rpkiclientweb/metrics.py
+++ b/rpkiclientweb/metrics.py
@@ -71,9 +71,9 @@ RPKI_CLIENT_RUNNING = Gauge(
 #
 # Metrics about retrieval behaviour
 #
-RPKI_CLIENT_FETCH_ERROR = Counter(
-    "rpkiclient_fetch_error",
-    "fetch errors encountered by rpki-client.",
+RPKI_CLIENT_FETCH_STATUS = Counter(
+    "rpkiclient_fetch_status",
+    "count of fetch status per repository and type encountered by rpki-client.",
     ["uri", "type"],
 )
 RPKI_CLIENT_PULLED = Gauge(

--- a/rpkiclientweb/rpki_client.py
+++ b/rpkiclientweb/rpki_client.py
@@ -17,7 +17,7 @@ from rpkiclientweb.metrics import (
     RPKI_CLIENT_LAST_UPDATE,
     RPKI_CLIENT_UPDATE_COUNT,
     RPKI_CLIENT_RUNNING,
-    RPKI_CLIENT_FETCH_ERROR,
+    RPKI_CLIENT_FETCH_STATUS,
     RPKI_CLIENT_PULLED,
     RPKI_CLIENT_PULLING,
     RPKI_CLIENT_REMOVED_UNREFERENCED,
@@ -223,7 +223,7 @@ class RpkiClient:
             RPKI_CLIENT_PULLED.labels(repo).set_to_current_time()
 
         for fetch_status in parsed.fetch_status:
-            RPKI_CLIENT_FETCH_ERROR.labels(
+            RPKI_CLIENT_FETCH_STATUS.labels(
                 uri=fetch_status.uri, type=fetch_status.type
             ).inc(fetch_status.count)
 


### PR DESCRIPTION
The metric that contains the status for fetching a repository
used to be called `rpkiclient_fetch_error_total`.

This metric also contains non-error statuses (such as when an RRDP
endpoint is not modified). That is why this metric was renamed to
`rpkiclient_fetch_status_total`

Fixes #26.