### PR TITLE
Metric for VRPs per TA

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Changes
 =======
 
 dev:
-  * rename `rpkiclient_fetch_error` metric to `rpkiclient_fetch_status` since it
+  * Add a metric for the number of VRPs per trust anchor locator.
+  * Rename `rpkiclient_fetch_error` metric to `rpkiclient_fetch_status` since it
     includes non-error statuses (fixes #26).
   * aiohttp >= 3.7.4.
   * more resilient rejection of intertwined lines.

--- a/rpkiclientweb/metrics.py
+++ b/rpkiclientweb/metrics.py
@@ -103,11 +103,17 @@ RPKI_OBJECTS_MIN_EXPIRY = Gauge(
     ["ta"],
 )
 
+RPKI_OBJECTS_VRPS_BY_TA = Gauge(
+    "rpki_vrps",
+    "Number of exported Validated Roa Payloads by Trust Anchor",
+    ["ta"],
+)
+
 #
 # Metrics about rpki-client-web
 #
 RPKI_CLIENT_WEB_PARSE_ERROR = Counter(
     "rpkiclientweb_parse_error",
-    "Number of pare errors encountered by rpki-client-web",
+    "Number of parse errors encountered by rpki-client-web",
     ["type"],
 )


### PR DESCRIPTION
Because of a feature request: Adds a metric for the number of VRPs per TA.
```
# HELP rpki_vrps Number of exported Validated Roa Payloads by Trust Anchor
# TYPE rpki_vrps gauge
rpki_vrps{ta="apnic"} 75045.0
rpki_vrps{ta="ripe"} 132442.0
rpki_vrps{ta="lacnic"} 14911.0
rpki_vrps{ta="afrinic"} 2478.0
```