### PR TITLE
Fix error on initial request

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ dev:
     Fixes #48.
   * Update interval to 1200s in the sample config
   * Add new `.metadata` keys from the json, and use buildtime in a separate metric.
+  * Return HTTP 503 Service Unavailable when JSON output does not exist.
 
 2021-11-14 0.9.1:
 ** Includes rpki-client 7.5 in the container**


### PR DESCRIPTION
Handle missing validated objects file
    
  * HTTP 500 on missing file after initial run.
  * HTTP 503 when not ready yet.

Fixes #41 