### PR TITLE
Track fallback to cache status and no manifest available warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pip-wheel-metadata
 .vagrant
 .autoenv.zsh
 __pycache__
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ dev:
   * Add new `.metadata` keys from the json, and use buildtime in a separate metric.
   * Return HTTP 503 Service Unavailable when JSON output does not exist.
   * Include console output in web index page
+  * "fallback to cache" is included in metrics
 
 2021-11-14 0.9.1:
 ** Includes rpki-client 7.5 in the container**

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ dev:
   * Add new `.metadata` keys from the json, and use buildtime in a separate metric.
   * Return HTTP 503 Service Unavailable when JSON output does not exist.
   * Include console output in web index page
-  * "fallback to cache" is included in metrics
+  * "fallback to cache" is included in the metrics
+  * "no valid mft available" warning is included in the metrics
 
 2021-11-14 0.9.1:
 ** Includes rpki-client 7.5 in the container**

--- a/rpkiclientweb/outputparser.py
+++ b/rpkiclientweb/outputparser.py
@@ -18,6 +18,9 @@ BAD_MESSAGE_DIGEST_RE = re.compile(
 EXPIRED_MANIFEST_RE = re.compile(
     r"rpki-client: (?P<path>.*): mft expired on (?P<expiry>.*)"
 )
+NO_MANIFEST_AVAILABLE_RE = re.compile(
+    r"rpki-client: (?P<path>.*): no valid mft available"
+)
 MISSING_FILE_RE = re.compile(r"rpki-client: (?P<path>.*): No such file or directory")
 PULLING_RE = re.compile(r"rpki-client: (?P<uri>.*): pulling from network")
 PULLED_RE = re.compile(r"rpki-client: (?P<uri>.*): loaded from network")
@@ -130,6 +133,10 @@ def parse_maybe_warning_line(line) -> Generator[RPKIClientWarning, None, None]:
     revoked_cert = REVOKED_CERTIFICATE.match(line)
     if revoked_cert:
         yield LabelWarning("revoked_certificate", revoked_cert.group("path"))
+
+    no_valid_mft = NO_MANIFEST_AVAILABLE_RE.match(line)
+    if no_valid_mft:
+        yield LabelWarning("no_valid_mft_available", no_valid_mft.group("path"))
 
     # Follow with more specific warnings
 

--- a/tests/20220223_no_valid_mft_available.txt
+++ b/tests/20220223_no_valid_mft_available.txt
@@ -1,0 +1,6 @@
+rpki-client: .rsync/0.sb/repo: load from network failed, fallback to cache
+rpki-client: 0.sb/repo/sb/30/F8CE54A4C62E61B125423FA90CA3F9D8350C7D3D.mft: no valid mft available
+rpki-client: 0.sb/repo/sb/15/DFB459F0D5057F7F3E19ADFCDA1765EE0603ACF7.mft: no valid mft available
+rpki-client: 0.sb/repo/sb/23/C56EB66B96238B09E2EBD0F8687F9A08FE325C94.mft: no valid mft available
+rpki-client: 0.sb/repo/sb/13/CD64F5400AFD2E66A071A72AE1F44827183AFBA1.mft: no valid mft available
+rpki-client: all files parsed: generating output

--- a/tests/test_outputparser.py
+++ b/tests/test_outputparser.py
@@ -61,6 +61,10 @@ def test_parse_sample_aggregated():
         )
         in parser.warnings
     )
+    #  rpki-client: nostromo.heficed.net/repo: load from network failed, fallback to cache
+    assert FetchStatus("nostromo.heficed.net/repo", "sync_fallback_to_cache") in list(
+        parser.fetch_status
+    )
 
 
 def test_twnic_revoked_objects():

--- a/tests/test_outputparser.py
+++ b/tests/test_outputparser.py
@@ -175,6 +175,19 @@ def test_missing_labels():
     assert missing_labels(after, before) == frozenset()
 
 
+def test_rpki_object_no_valid_mft_available():
+    """No valid manifest available errors."""
+    res = parse_output_file("tests/20220223_no_valid_mft_available.txt")
+
+    assert (
+        LabelWarning(
+            warning_type="no_valid_mft_available",
+            uri="0.sb/repo/sb/30/F8CE54A4C62E61B125423FA90CA3F9D8350C7D3D.mft",
+        )
+        in res.warnings
+    )
+
+
 def test_rsync_errors():
     """Test a situation with many rsync errors."""
     res = parse_output_file("tests/20210610_sample_rsync_errors.txt")
@@ -252,6 +265,16 @@ def test_rsync_fallback():
     assert FetchStatus(
         "https://rrdp.ripe.net/notification.xml", "rrdp_rsync_fallback"
     ) in list(res.fetch_status)
+
+
+def test_fallback_to_cache():
+    """Test the situation where a repo falls back to cache."""
+    parser = parse_output_file("tests/sample_aggregated_output.txt")
+
+    #  rpki-client: nostromo.heficed.net/repo: load from network failed, fallback to cache
+    assert FetchStatus("nostromo.heficed.net/repo", "sync_fallback_to_cache") in list(
+        parser.fetch_status
+    )
 
 
 def test_intertwined_rrdp_lines_20210614():


### PR DESCRIPTION
Track the warnings when:
  * a repo falls back to cache
  * no valid manifest is available for a CA (rpki-client 7.6 specific warning)

Fixes #45 