### PR TITLE
Improve output of rsync_timeout

### DIFF
--- a/util/rsync_timeout
+++ b/util/rsync_timeout
@@ -36,7 +36,7 @@ if deadline is not None:
         args.extend(sys_args)
         os.execv("/usr/bin/timeout", args)
     else:
-        print("rsync_timeout: Skipping execution, post deadline")
+        print(f"rsync_timeout: Skipping execution, post deadline. Arguments: {' '.join(sys_args)}", file=sys.stderr)
         # man rsync, exit code 20: Received SIGUSR1 or SIGIN
         sys.exit(20)
 else:


### PR DESCRIPTION
Output the skipped execution on stderr so it is in-line with the other output if one captures stdout and stderr separately.