### PR TITLE
Use -s timeout of rpki-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ dev:
   * track rrdp serial decrease in metric
   * track repository not modified message
   * improve output of rsync_timeout
+  * **Behavioural change**: use rpki-client `-s` timeout set to the kill timeout.
 
 2022-04-13 0.10.0:
 **Includes rpki-client 7.8 in the container, raising the object size limit**

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/fedora35"
+  config.vm.box = "generic/fedora36"
 
   config.vm.network "forwarded_port", guest: 8888, host: 8888, host_ip: "127.0.0.1"
 

--- a/rpkiclientweb/rpki_client.py
+++ b/rpkiclientweb/rpki_client.py
@@ -141,11 +141,11 @@ class RpkiClient:
                 f"illegal timeout: {self.config.timeout} -- should be >= -1"
             )
 
-        # Not using `-s [timeout]` for now because the timeout is managed from
-        # this wrapping code.
         args = [
             "-v",  # verbose
             "-j",  # JSON output
+            # repositories can take 1/4th of this time before rpki-client aborts
+            "-s", str(self.config.timeout),
             "-d",
             self.config.cache_dir,
         ]


### PR DESCRIPTION
Use rpki-client's `-s` parameter to have better timeouts. This may prevent runs from timing out.