### PR TITLE
Use rpki-client 8.0 in container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,6 @@ output
 .pytest_cache
 .vagrant
 .autoenv.zsh
+azure-pipelines.yml
+Vagrantfile
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/rpkiclientweb
 
 # Use dependencies from fedora as much as possible, saves building them and build deps.
 RUN dnf --setopt=install_weak_deps=False --best install -y python3-aiohttp python3-pyyaml python3-pip python3-wrapt git\
-  && dnf install -y rpki-client --enablerepo=updates-testing,updates-testing-modular --best \
+  && dnf install -y rpki-client --enablerepo=updates-testing,updates-testing-modular --advisory=FEDORA-2022-f7ec4ce917 --best \
   && dnf clean all \
   && rm -rf /var/cache/yum
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ Endpoints
 
 Changes
 =======
-202x-xx-xx HEAD:
+2022-xx-xx DEV:
 
   * track rrdp snapshot fallback
   * track http 404 errors
+  * rpki-client 8.0 in container image
 
 2022-09-12 0.11.0:
 


### PR DESCRIPTION
rpki-client 8.0 is available for Fedora 36 (in testing repo, not pushed to updates). Use it in the image.