### PR TITLE
WIP: Include open metrics in /metrics and other small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Changes
   * **deprecated VRPS by TA metrics, since those are covered in openmetrics metrics**. Will be released >6 months after this release.
   * Include VAPs and bgpsec keys in the tracked 'time to first object expiring'
   * Include rpki-client openmetrics in `/metrics` output.
+  * Enable HTTP compression for validated objects file
 
 2022-11-11 0.12.0:
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Changes
   * Build using poetry and revisit build process
   * Add metric for JSON parse errors
   * Add metrics for recent attributes
+  * **deprecated VRPS by TA metrics, since those are covered in openmetrics metrics**. Will be released >6 months after this release.
+  * Include VAPs and bgpsec keys in the tracked 'time to first object expiring'
+  * Include rpki-client openmetrics in `/metrics` output.
 
 2022-11-11 0.12.0:
 

--- a/rpkiclientweb/web.py
+++ b/rpkiclientweb/web.py
@@ -48,6 +48,7 @@ class RpkiClientWeb:
         )
 
     async def index(self, req) -> web.Response:
+        """Human readable index page."""
         return web.Response(
             text=f"""<html>
             <head><title>rpki-client wrapper</title></head>
@@ -74,7 +75,9 @@ class RpkiClientWeb:
         """return the validated objects json."""
         path = self.config.output_dir / "json"
         if path.is_file():
-            return web.FileResponse(path, headers={"Content-Type": "application/json"})
+            resp = web.FileResponse(path, headers={"Content-Type": "application/json"})
+            resp.enable_compression()
+            return resp
 
         status = (
             "validated objects JSON file is not available at the moment."
@@ -97,6 +100,7 @@ class RpkiClientWeb:
         self.finished_initial_run = True
 
     async def json_result(self, req) -> web.Response:
+        """return a description of the last execution result."""
         if self.result:
             return web.json_response(self.result, dumps=json_dumps)
 


### PR DESCRIPTION
  * **deprecated VRPS by TA metrics, since those are covered in openmetrics metrics**. Will be released >6 months after this release.
  * Include VAPs and bgpsec keys in the tracked 'time to first object expiring'
  * Include rpki-client openmetrics in `/metrics` output.
  * Enable HTTP compression for validated objects file