### PR TITLE
Track fetch status errors from 8.4

### DIFF
--- a/rpkiclientweb/parsing.py
+++ b/rpkiclientweb/parsing.py
@@ -90,8 +90,9 @@ SYNC_RSYNC_RRDP_SNAPSHOT = re.compile(
     r"rpki-client: (?P<uri>.*): downloading snapshot$"
 )
 SYNC_RSYNC_RRDP_DELTAS = re.compile(
-    r"rpki-client: (?P<uri>.*): downloading (?P<count>\d+) deltas$"
+    r"rpki-client: (?P<uri>.*): downloading (?P<count>\d+) deltas( \((?P<session>[A-z0-9\-]+)#(?P<serial>[0-9]+)\))?$"
 )
+
 SYNC_RRDP_PARSE_ABORTED = re.compile(
     r"rpki-client: (?P<uri>.*): parse error at line [0-9]+: parsing aborted"
 )
@@ -296,9 +297,7 @@ def parse_fetch_status(line: str) -> Generator[FetchStatus, None, None]:  # noqa
 
     file_bad_message_digest = SYNC_RRDP_BAD_FILE_DIGEST.match(line)
     if file_bad_message_digest:
-        yield FetchStatus(
-            file_bad_message_digest.group("uri"), "sync_bad_message_digest"
-        )
+        yield FetchStatus(file_bad_message_digest.group("uri"), "sync_bad_file_digest")
         return
 
     snapshot_fallback = SYNC_RRDP_SNAPSHOT_FALLBACK.match(line)

--- a/rpkiclientweb/parsing.py
+++ b/rpkiclientweb/parsing.py
@@ -90,7 +90,7 @@ SYNC_RSYNC_RRDP_SNAPSHOT = re.compile(
     r"rpki-client: (?P<uri>.*): downloading snapshot$"
 )
 SYNC_RSYNC_RRDP_DELTAS = re.compile(
-    r"rpki-client: (?P<uri>.*): downloading (?P<count>\d+) deltas( \((?P<session>[A-z0-9\-]+)#(?P<serial>[0-9]+)\))?$"
+    r"rpki-client: (?P<uri>.*): downloading (?P<count>\d+) deltas( \((?P<session>[\w-]+)#(?P<serial>[0-9]+)\))?$"
 )
 
 SYNC_RRDP_PARSE_ABORTED = re.compile(

--- a/tests/inputs/20230509_full_output.txt
+++ b/tests/inputs/20230509_full_output.txt
@@ -1,0 +1,11 @@
+rpki-client: ta/example loaded from network
+rpki-client: https://rrdp.example.org/notification.xml: pulling from network
+rpki-client: https://rrdp.example.org/notification.xml: downloading 2 deltas (7ca10d7d-74c3-49de-aeb4-88e0634f081b#10064)
+rpki-client: https://rrdp.example.org/notification.xml: loaded from network
+rpki-client: https://rrdp.paas.rpki.example.org/notification.xml: pulling from network
+rpki-client: https://rrdp.paas.rpki.example.org/notification.xml: downloading 1 deltas (f610c790-8ceb-4711-bddd-938d0b16fa39#24265)
+rpki-client: https://rrdp.paas.rpki.example.org/notification.xml: bad file digest for rsync.paas.rpki.example.org/repository/66ba828b-6d57-4c5a-ac58-c43fbb841861/0/9E72449C21052596265AC642409D6DF62C5FFA9B.mft
+rpki-client: https://rrdp.paas.rpki.example.org/notification.xml: bad file digest for rsync.paas.rpki.example.org/repository/66ba828b-6d57-4c5a-ac58-c43fbb841861/0/9E72449C21052596265AC642409D6DF62C5FFA9B.crl
+rpki-client: https://rrdp.paas.rpki.example.org/notification.xml: delta sync failed, fallback to snapshot
+rpki-client: https://rrdp.paas.rpki.example.org/notification.xml: loaded from network
+rpki-client: all files parsed: generating output

--- a/tests/test_outputparser.py
+++ b/tests/test_outputparser.py
@@ -189,9 +189,7 @@ def test_rpki_client_failed_download_digest_warnings() -> None:
 
     c = count_fetch_status(res)
 
-    assert (
-        c[("sync_bad_message_digest", "https://rrdp.example.org/notification.xml")] > 10
-    )
+    assert c[("sync_bad_file_digest", "https://rrdp.example.org/notification.xml")] > 10
 
 
 def test_roa_certificate_not_valid() -> None:

--- a/tests/test_outputparser_fetch_warnings.py
+++ b/tests/test_outputparser_fetch_warnings.py
@@ -70,6 +70,38 @@ def test_rrdp_deltas() -> None:
     ) in list(res.fetch_status)
 
 
+def test_rrdp_deltas_84() -> None:
+    res = parse_output_file("inputs/20230509_full_output.txt")
+    statuses = list(res.fetch_status)
+
+    assert (
+        FetchStatus("https://rrdp.example.org/notification.xml", "rrdp_delta", 2)
+        in statuses
+    )
+    assert (
+        FetchStatus(
+            "https://rrdp.paas.rpki.example.org/notification.xml", "rrdp_delta", 1
+        )
+        in statuses
+    )
+    assert (
+        FetchStatus(
+            "https://rrdp.paas.rpki.example.org/notification.xml",
+            "sync_bad_file_digest",
+            1,
+        )
+        in statuses
+    )
+    assert (
+        FetchStatus(
+            "https://rrdp.paas.rpki.example.org/notification.xml",
+            "rrdp_snapshot_fallback",
+            1,
+        )
+        in statuses
+    )
+
+
 def test_rrdp_parse_aborted() -> None:
     """Test a situation where parsing is aborted for rsync."""
     res = parse_output_file("inputs/20220311_sample_rrdp_rejected_file_too_large.txt")


### PR DESCRIPTION
Track the fetch status errors with the format that is in the output of rpki-client 8.4