### PR TITLE
Do not track a _file_ error on TLS failure during sync

### DIFF
--- a/rpkiclientweb/parsing.py
+++ b/rpkiclientweb/parsing.py
@@ -37,13 +37,13 @@ FILE_CMS_UNEXPECTED_SIGNED_ATTRIBUTE = re.compile(
 )
 # TODO: Consider a more elegant way of filtering out TLS handshake errors
 FILE_CERTIFICATE_EXPIRED = re.compile(
-    r"rpki-client: (?P<path>(?!TLS handshake:).+): certificate has expired"
+    r"rpki-client: (?P<path>[^:]+): certificate has expired"
 )
 FILE_CERTIFICATE_NOT_YET_VALID_RE = re.compile(
-    r"rpki-client: (?P<path>(?!TLS handshake:).+): certificate is not yet valid"
+    r"rpki-client: (?P<path>[^:]+): certificate is not yet valid"
 )
 FILE_CERTIFICATE_REVOKED_RE = re.compile(
-    r"rpki-client: (?P<path>(?!TLS handshake:).+): certificate revoked"
+    r"rpki-client: (?P<path>[^:]+): certificate revoked"
 )
 FILE_CERTIFICATE_6487_DUPLICATE_SKI = re.compile(
     r"rpki-client: (?P<path>.*): RFC 6487: duplicate SKI"

--- a/tests/test_outputparser_fetch_warnings.py
+++ b/tests/test_outputparser_fetch_warnings.py
@@ -179,6 +179,15 @@ def test_rrdp_tls_failure() -> None:
     assert FetchStatus("rpki.example.org", "tls_failure", 1) in res.fetch_status
 
 
+def test_rrdp_tls_failure_no_object_warning() -> None:
+    res = OutputParser(
+        "rpki-client: https://rpkica.mckay.com/rrdp/notify.xml (51.75.161.87): TLS handshake: certificate verification failed: certificate has expired"
+    )
+
+    assert len(list(res.fetch_status)) == 1
+    assert len(list(res.warnings)) == 0
+
+
 def test_fetch_error_no_ee_certificate_errorr() -> None:
     """Do not conflate TLS and EE certificate errors."""
     res = parse_output_file("inputs/20220905_tls_error_expired.txt")
@@ -192,7 +201,7 @@ def test_fetch_error_no_ee_certificate_errorr() -> None:
         in res.fetch_status
     )
     # But no EE certificate warning:
-    assert len(list(res.warnings)) != 0
+    assert len(list(res.warnings)) == 0
 
 
 def test_fetch_error_connect_errors() -> None:


### PR DESCRIPTION
Lines like below would cause a warning for `https:` as URL,
```
rpki-client: https://rpkica.mckay.com/rrdp/notify.xml (51.75.161.87): TLS handshake: certificate verification failed: certificate has expired
```